### PR TITLE
Use JRE instead of JDK as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM java:8
 MAINTAINER Jan Schulte <jan@janschulte.com>
 
 ENV TRIFECTA_VERSION=0.21.0 TRIFECTA_URL=https://github.com/ldaniels528/trifecta/releases/download


### PR DESCRIPTION
As no JDK is required, use a JRE only image as base.
